### PR TITLE
Sdn 101/faeture/dockerfile UI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+node_modules
+.env
+.env.*
+.next/
+.cache/
+*.md
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+# Required at runtime (pass via -e or --env-file):
+# MONOLITH_API_BASE_URL=
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+RUN apk add --no-cache curl
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:3000/api/health || exit 1
+
+USER nextjs
+EXPOSE 3000
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+CMD ["node", "server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:20-alpine AS builder
 WORKDIR /app
 
+RUN apk upgrade --no-cache
+
 COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
@@ -10,10 +12,12 @@ FROM node:20-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
 # Required at runtime (pass via -e or --env-file):
 # MONOLITH_API_BASE_URL=
 
-RUN addgroup --system --gid 1001 nodejs && \
+RUN apk upgrade --no-cache && \
+    addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 
 COPY --from=builder /app/public ./public

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  output: 'standalone',
   env: {
     MONOLITH_API_BASE_URL: process.env.MONOLITH_API_BASE_URL,
   },

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,3 @@
+export async function GET() {
+  return Response.json({ status: 'ok' });
+}


### PR DESCRIPTION
## Ticket 🎫

### [PGZ-101: [UI] Dockerfile and Repo Changes — pegazzo-dashboard-ui](https://kapibaras.atlassian.net/browse/PGZ-101)                               
## Type of change ♻️                                                                                                                              ─

- [x] ✨ Feature
- [ ] 🐛 Bugfix
- [ ] ⚡️Improvement
- [ ] 🔧 Chore

## What was done ❓

- Added `output: 'standalone'` to `next.config.ts` to enable self-contained server output required for containerized deployment
- Created multi-stage `Dockerfile` (builder + runner stages using `node:20-alpine`) that copies only `.next/standalone`, `.next/static`, and `public` into the final image
- Created `.dockerignore` to exclude unnecessary files from the build context
- Added `GET /api/health` endpoint (no auth required) to support Docker healthcheck

## Evidence 📷
<img width="1375" height="614" alt="Captura de pantalla 2026-06-06 234543" src="https://github.com/user-attachments/assets/2f68ecbd-be2e-4c38-a6c5-ed0dd0855208" />

## Checklist 📋

- [x] ⏭️ PR Branch has been **rebased** with `main`.
- [x] 🔎 Code and Functionality has been **self-reviewed** by the author.
- [x] 📝 PR Template has been **filled out**.
