### PR TITLE
🔧PGZ-108/110/111 — GitHub Actions CI/CD pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,70 @@
+name: Build & Deploy
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-push:
+    name: Build & Push Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Build and push image on KVM
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE: registry.pegazzoauto.com/pegazzo-dashboard
+        with:
+          host: 2.24.115.10
+          username: pegazzo
+          key: ${{ secrets.KVM_SSH_KEY }}
+          command_timeout: 30m
+          envs: GH_TOKEN,IMAGE
+          script: |
+            docker pull $IMAGE:main && \
+              docker tag $IMAGE:main $IMAGE:previous && \
+              docker push $IMAGE:previous || true
+
+            trap 'rm -rf /tmp/dashboard-build' EXIT
+            rm -rf /tmp/dashboard-build
+            git clone https://x-access-token:$GH_TOKEN@github.com/Kapibaras/pegazzo-dashboard-ui.git /tmp/dashboard-build
+            docker build -t $IMAGE:main /tmp/dashboard-build
+            docker push $IMAGE:main
+            rm -rf /tmp/dashboard-build
+
+  deploy-staging:
+    name: Deploy to Staging
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    environment: staging
+
+    concurrency:
+      group: deploy-staging
+      cancel-in-progress: false
+
+    steps:
+      - name: Trigger Dokploy staging webhook
+        env:
+          WEBHOOK_URL: ${{ secrets.DOKPLOY_DASHBOARD_STAGING_WEBHOOK }}
+        run: curl -fsS -X POST "$WEBHOOK_URL"
+
+  deploy-production:
+    name: Deploy to Production
+    needs: deploy-staging
+    runs-on: ubuntu-latest
+    environment: production
+
+    concurrency:
+      group: deploy-production
+      cancel-in-progress: false
+
+    steps:
+      - name: Trigger Dokploy production webhook
+        env:
+          WEBHOOK_URL: ${{ secrets.DOKPLOY_DASHBOARD_PRODUCTION_WEBHOOK }}
+        run: curl -fsS -X POST "$WEBHOOK_URL"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Build and push image on KVM
-        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2
+        uses: appleboy/ssh-action@v1.2.0
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IMAGE: registry.pegazzoauto.com/pegazzo-dashboard

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,19 +52,3 @@ jobs:
         env:
           WEBHOOK_URL: ${{ secrets.DOKPLOY_DASHBOARD_STAGING_WEBHOOK }}
         run: curl -fsS -X POST "$WEBHOOK_URL"
-
-  deploy-production:
-    name: Deploy to Production
-    needs: deploy-staging
-    runs-on: ubuntu-latest
-    environment: production
-
-    concurrency:
-      group: deploy-production
-      cancel-in-progress: false
-
-    steps:
-      - name: Trigger Dokploy production webhook
-        env:
-          WEBHOOK_URL: ${{ secrets.DOKPLOY_DASHBOARD_PRODUCTION_WEBHOOK }}
-        run: curl -fsS -X POST "$WEBHOOK_URL"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-and-typecheck:
+    name: Lint & Type Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type check
+        run: npx tsc --noEmit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Retag :main → :<tag> + :latest on KVM
-        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2
+        uses: appleboy/ssh-action@v1.2.0
         env:
           IMAGE: registry.pegazzoauto.com/pegazzo-dashboard
           TAG: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  retag:
+    name: Retag Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Retag :main → :<tag> + :latest on KVM
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2
+        env:
+          IMAGE: registry.pegazzoauto.com/pegazzo-dashboard
+          TAG: ${{ github.ref_name }}
+        with:
+          host: 2.24.115.10
+          username: pegazzo
+          key: ${{ secrets.KVM_SSH_KEY }}
+          command_timeout: 10m
+          envs: IMAGE,TAG
+          script: |
+            docker pull $IMAGE:main
+            docker tag $IMAGE:main $IMAGE:$TAG
+            docker tag $IMAGE:main $IMAGE:latest
+            docker push $IMAGE:$TAG
+            docker push $IMAGE:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 concurrency:
   group: release-${{ github.ref }}
@@ -19,7 +18,7 @@ jobs:
         uses: appleboy/ssh-action@v1.2.0
         env:
           IMAGE: registry.pegazzoauto.com/pegazzo-dashboard
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ github.event.release.tag_name }}
         with:
           host: 2.24.115.10
           username: pegazzo
@@ -32,3 +31,19 @@ jobs:
             docker tag $IMAGE:main $IMAGE:latest
             docker push $IMAGE:$TAG
             docker push $IMAGE:latest
+
+  deploy-production:
+    name: Deploy to Production
+    needs: retag
+    runs-on: ubuntu-latest
+    environment: production
+
+    concurrency:
+      group: deploy-production
+      cancel-in-progress: false
+
+    steps:
+      - name: Trigger Dokploy production webhook
+        env:
+          WEBHOOK_URL: ${{ secrets.DOKPLOY_DASHBOARD_PRODUCTION_WEBHOOK }}
+        run: curl -fsS -X POST "$WEBHOOK_URL"

--- a/src/api/clients/base.ts
+++ b/src/api/clients/base.ts
@@ -12,14 +12,16 @@ export default class APIClientBase {
     return this.axiosInstance;
   }
 
-  public async get<T = unknown>(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public async get<T = any>(
     url: string,
     config?: AxiosRequestConfig
   ): Promise<AxiosResponse<T>> {
     return this.axiosInstance.get<T>(url, config);
   }
 
-  public async post<T = unknown>(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public async post<T = any>(
     url: string,
     data?: unknown,
     config?: AxiosRequestConfig
@@ -27,7 +29,8 @@ export default class APIClientBase {
     return this.axiosInstance.post<T>(url, data, config);
   }
 
-  public async put<T = unknown>(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public async put<T = any>(
     url: string,
     data?: unknown,
     config?: AxiosRequestConfig
@@ -35,7 +38,8 @@ export default class APIClientBase {
     return this.axiosInstance.put<T>(url, data, config);
   }
 
-  public async patch<T = unknown>(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public async patch<T = any>(
     url: string,
     data?: unknown,
     config?: AxiosRequestConfig
@@ -43,7 +47,8 @@ export default class APIClientBase {
     return this.axiosInstance.patch<T>(url, data, config);
   }
 
-  public async delete<T = unknown>(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public async delete<T = any>(
     url: string,
     config?: AxiosRequestConfig
   ): Promise<AxiosResponse<T>> {

--- a/src/api/clients/base.ts
+++ b/src/api/clients/base.ts
@@ -12,38 +12,38 @@ export default class APIClientBase {
     return this.axiosInstance;
   }
 
-  public async get<T = any>(
+  public async get<T = unknown>(
     url: string,
     config?: AxiosRequestConfig
   ): Promise<AxiosResponse<T>> {
     return this.axiosInstance.get<T>(url, config);
   }
 
-  public async post<T = any>(
+  public async post<T = unknown>(
     url: string,
-    data?: any,
+    data?: unknown,
     config?: AxiosRequestConfig
   ): Promise<AxiosResponse<T>> {
     return this.axiosInstance.post<T>(url, data, config);
   }
 
-  public async put<T = any>(
+  public async put<T = unknown>(
     url: string,
-    data?: any,
+    data?: unknown,
     config?: AxiosRequestConfig
   ): Promise<AxiosResponse<T>> {
     return this.axiosInstance.put<T>(url, data, config);
   }
 
-  public async patch<T = any>(
+  public async patch<T = unknown>(
     url: string,
-    data?: any,
+    data?: unknown,
     config?: AxiosRequestConfig
   ): Promise<AxiosResponse<T>> {
     return this.axiosInstance.patch<T>(url, data, config);
   }
 
-  public async delete<T = any>(
+  public async delete<T = unknown>(
     url: string,
     config?: AxiosRequestConfig
   ): Promise<AxiosResponse<T>> {

--- a/src/api/clients/base.ts
+++ b/src/api/clients/base.ts
@@ -12,16 +12,14 @@ export default class APIClientBase {
     return this.axiosInstance;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public async get<T = any>(
+  public async get<T = unknown>(
     url: string,
     config?: AxiosRequestConfig
   ): Promise<AxiosResponse<T>> {
     return this.axiosInstance.get<T>(url, config);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public async post<T = any>(
+  public async post<T = unknown>(
     url: string,
     data?: unknown,
     config?: AxiosRequestConfig
@@ -29,8 +27,7 @@ export default class APIClientBase {
     return this.axiosInstance.post<T>(url, data, config);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public async put<T = any>(
+  public async put<T = unknown>(
     url: string,
     data?: unknown,
     config?: AxiosRequestConfig
@@ -38,8 +35,7 @@ export default class APIClientBase {
     return this.axiosInstance.put<T>(url, data, config);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public async patch<T = any>(
+  public async patch<T = unknown>(
     url: string,
     data?: unknown,
     config?: AxiosRequestConfig
@@ -47,8 +43,7 @@ export default class APIClientBase {
     return this.axiosInstance.patch<T>(url, data, config);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public async delete<T = any>(
+  public async delete<T = unknown>(
     url: string,
     config?: AxiosRequestConfig
   ): Promise<AxiosResponse<T>> {

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-const GlobalError = ({ reset }: { error: Error & { digest?: string }; reset: () => void }) => {
+const GlobalError = (_props: { error: Error & { digest?: string }; reset: () => void }) => {
   return (
     <html lang="es">
       <body className="flex min-h-screen items-center justify-center bg-[#0a192b] p-6">

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-const GlobalError = (_props: { error: Error & { digest?: string }; reset: () => void }) => {
+const GlobalError = () => {
   return (
     <html lang="es">
       <body className="flex min-h-screen items-center justify-center bg-[#0a192b] p-6">

--- a/src/components/balance/transactions/DatePickerField.tsx
+++ b/src/components/balance/transactions/DatePickerField.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { format, subMonths, isAfter, isBefore } from 'date-fns';
 import { es } from 'date-fns/locale';
-import { CalendarDays, Clock } from 'lucide-react';
+import { CalendarDays } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { parseDateOnly, toLocalISOWithOffset } from '@/utils/formatters';
 import { Calendar } from '@/components/ui/calendar';

--- a/src/components/balance/transactions/TransactionForm.tsx
+++ b/src/components/balance/transactions/TransactionForm.tsx
@@ -59,12 +59,13 @@ const TransactionForm = ({
   const schema = mode === 'create' ? createTransactionSchema : editTransactionSchema;
 
   const form = useForm<CreateTransactionFormValues | EditTransactionFormValues>({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     resolver: zodResolver(schema) as any,
     defaultValues:
       defaultValues ??
       (mode === 'create'
         ? {
-            amount: '' as any,
+            amount: '' as unknown as number,
             date: undefined,
             type: undefined,
             category_group: '',
@@ -73,7 +74,7 @@ const TransactionForm = ({
             payment_method: undefined,
           }
         : {
-            amount: '' as any,
+            amount: '' as unknown as number,
             description: '',
             payment_method: undefined,
             category_group: '',

--- a/src/components/users/UserForm.tsx
+++ b/src/components/users/UserForm.tsx
@@ -71,8 +71,9 @@ export function UserForm({ mode, onSuccess, userId, name, surnames }: UserFormPr
           };
 
   const form = useForm<UserFormValues | UpdateNamesFormValues | UpdatePasswordFormValues>({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     resolver: zodResolver(schema) as any,
-    defaultValues: defaultValues as any,
+    defaultValues: defaultValues as Partial<UserFormValues | UpdateNamesFormValues | UpdatePasswordFormValues>,
     mode: 'onChange',
   });
 
@@ -107,7 +108,7 @@ export function UserForm({ mode, onSuccess, userId, name, surnames }: UserFormPr
     ToastService.success(buttonLabels[mode].title, buttonLabels[mode].success);
 
     onSuccess();
-    form.reset(defaultValues as any);
+    form.reset(defaultValues as Partial<UserFormValues | UpdateNamesFormValues | UpdatePasswordFormValues>);
   }
 
   return (

--- a/src/helpers/handleUserAction.ts
+++ b/src/helpers/handleUserAction.ts
@@ -61,7 +61,7 @@ export default async function handleUserAction({
       const username = actionType === 'create' ? undefined : (data.userId ?? data.username);
       const args = username !== undefined ? [userService, username, validated.data] : [userService, validated.data];
 
-      const result = await action(...args);
+      const result = await action(...(args as [UserService, ...unknown[]]));
 
       revalidatePath('/dashboard/users');
 

--- a/src/helpers/handleUserAction.ts
+++ b/src/helpers/handleUserAction.ts
@@ -13,7 +13,8 @@ type ActionType = 'create' | 'updateNames' | 'updatePassword';
 interface HandleUserActionProps {
   formData: FormData;
   actionType: ActionType;
-  action: (...args: unknown[]) => Promise<unknown>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  action: (...args: any[]) => Promise<any>;
   successMessage: string;
   errorMessage: string;
 }

--- a/src/helpers/handleUserAction.ts
+++ b/src/helpers/handleUserAction.ts
@@ -14,7 +14,7 @@ interface HandleUserActionProps {
   formData: FormData;
   actionType: ActionType;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  action: (...args: any[]) => Promise<any>;
+  action: (service: UserService, ...args: any[]) => Promise<unknown>;
   successMessage: string;
   errorMessage: string;
 }

--- a/src/helpers/handleUserAction.ts
+++ b/src/helpers/handleUserAction.ts
@@ -13,7 +13,7 @@ type ActionType = 'create' | 'updateNames' | 'updatePassword';
 interface HandleUserActionProps {
   formData: FormData;
   actionType: ActionType;
-  action: (...args: any[]) => Promise<any>;
+  action: (...args: unknown[]) => Promise<unknown>;
   successMessage: string;
   errorMessage: string;
 }
@@ -21,7 +21,7 @@ interface HandleUserActionProps {
 interface HandleUserActionResult {
   success: boolean;
   message?: string;
-  data?: any;
+  data?: unknown;
   errors?: Record<string, string[]>;
   status?: number;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -18,7 +18,7 @@ export async function middleware(request: NextRequest) {
       const secret = new TextEncoder().encode(VARIABLES.NEXT_SESSION_SECRET);
       const { payload } = await jwtVerify(session, secret);
       sessionPayload = payload;
-    } catch (error) {
+    } catch {
     }
   }
   

--- a/src/services/balance.ts
+++ b/src/services/balance.ts
@@ -24,31 +24,31 @@ export default class BalanceService extends AbstractAPIService {
   }
 
   async getSimpleMetrics(params?: { month?: number; year?: number }): Promise<BalanceMetricsSimple> {
-    return (await this.client.get('/management/balance/metrics/simple', { params })).data;
+    return (await this.client.get<BalanceMetricsSimple>('/management/balance/metrics/simple', { params })).data;
   }
 
   async getDetailedMetrics(params: BalanceMetricsParams): Promise<BalanceMetricsDetailed> {
-    return (await this.client.get('/management/balance/metrics', { params })).data;
+    return (await this.client.get<BalanceMetricsDetailed>('/management/balance/metrics', { params })).data;
   }
 
   async getTrendData(params: BalanceTrendParams): Promise<BalanceTrendResponse> {
-    return (await this.client.get('/management/balance/metrics/trend', { params })).data;
+    return (await this.client.get<BalanceTrendResponse>('/management/balance/metrics/trend', { params })).data;
   }
 
   async getTransactions(params: TransactionsParams): Promise<TransactionsResponse> {
-    return (await this.client.get('/management/balance/transactions', { params })).data;
+    return (await this.client.get<TransactionsResponse>('/management/balance/transactions', { params })).data;
   }
 
   async createTransaction(data: TransactionCreate): Promise<Transaction> {
-    return (await this.client.post('/management/balance/transaction', data)).data;
+    return (await this.client.post<Transaction>('/management/balance/transaction', data)).data;
   }
 
   async getTransaction(reference: string): Promise<Transaction> {
-    return (await this.client.get(`/management/balance/transaction/${reference}`)).data;
+    return (await this.client.get<Transaction>(`/management/balance/transaction/${reference}`)).data;
   }
 
   async updateTransaction(reference: string, data: TransactionPatch): Promise<Transaction> {
-    return (await this.client.patch(`/management/balance/transaction/${reference}`, data)).data;
+    return (await this.client.patch<Transaction>(`/management/balance/transaction/${reference}`, data)).data;
   }
 
   async deleteTransaction(reference: string): Promise<void> {
@@ -56,10 +56,10 @@ export default class BalanceService extends AbstractAPIService {
   }
 
   async authorizeTransaction(reference: string, payload: TransactionAuthorizationPayload): Promise<Transaction> {
-    return (await this.client.post(`/management/balance/transaction/${reference}/authorization`, payload)).data;
+    return (await this.client.post<Transaction>(`/management/balance/transaction/${reference}/authorization`, payload)).data;
   }
 
   async getTransactionsCount(params?: TransactionsCountParams): Promise<TransactionCount> {
-    return (await this.client.get('/management/balance/transactions/count', { params })).data;
+    return (await this.client.get<TransactionCount>('/management/balance/transactions/count', { params })).data;
   }
 }

--- a/src/services/base/AbstractAPIService.ts
+++ b/src/services/base/AbstractAPIService.ts
@@ -6,7 +6,7 @@ import AuthService from '../auth';
 export default abstract class AbstractAPIService {
   protected readonly client: APIClientBase;
   private isRefreshing = false;
-  private refreshPromise: Promise<any> | null = null;
+  private refreshPromise: Promise<unknown> | null = null;
 
   constructor(client: APIClientBase) {
     this.client = client;

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -8,11 +8,11 @@ export default class UserService extends AbstractAPIService {
   }
 
   async getAllUsers(role?: string): Promise<User[]> {
-    return (await this.client.get('/internal/user', { params: role ? { role } : {} })).data;
+    return (await this.client.get<User[]>('/internal/user', { params: role ? { role } : {} })).data;
   }
 
   async getUserByUsername(username: string): Promise<User> {
-    return (await this.client.get(`/internal/user/${username}`)).data;
+    return (await this.client.get<User>(`/internal/user/${username}`)).data;
   }
 
   async createUser(data: {
@@ -22,7 +22,7 @@ export default class UserService extends AbstractAPIService {
     password: string;
     role: string;
   }): Promise<User> {
-    const response = await this.client.post('/internal/user', data);
+    const response = await this.client.post<User>('/internal/user', data);
     return response.data;
   }
 
@@ -33,17 +33,17 @@ export default class UserService extends AbstractAPIService {
       surnames: string;
     },
   ): Promise<User> {
-    const response = await this.client.patch(`/internal/user/${username}/name`, data);
+    const response = await this.client.patch<User>(`/internal/user/${username}/name`, data);
     return response.data;
   }
 
   async updateUserPassword(username: string, data: { password: string }): Promise<User> {
-    const response = await this.client.patch(`/internal/user/${username}/password`, data);
+    const response = await this.client.patch<User>(`/internal/user/${username}/password`, data);
     return response.data;
   }
 
   async updateUserRole(username: string, role: string): Promise<User> {
-    const response = await this.client.patch(`/internal/user/${username}/role`, { role });
+    const response = await this.client.patch<User>(`/internal/user/${username}/role`, { role });
     return response.data;
   }
 


### PR DESCRIPTION
## Ticket 🎫

### [PGZ-108: CI workflow](https://pegazzoauto.atlassian.net/browse/PGZ-108) / [PGZ-110: Build & Deploy workflow](https://pegazzoauto.atlassian.net/browse/PGZ-110) / [PGZ-111: Release workflow](https://pegazzoauto.atlassian.net/browse/PGZ-111)

## Type of change ♻️

- [ ] ✨ Feature
- [ ] 🐛 Bugfix
- [ ] ⚡️ Improvement
- [x] 🔧 Chore

## What was done ❓

- **`ci.yml`** — Runs `npm run lint` + `npx tsc --noEmit` on every PR targeting `main`. Uses `cancel-in-progress: true` so re-pushes to the same branch cancel previous runs.
- **`build.yml`** — Triggered on push to `main`. Builds the Docker image on the KVM server via SSH (avoids Cloudflare R2 multipart upload issue from GH runner IPs), preserves `:previous` tag before overwriting `:main` for rollback, then deploys to staging automatically and production behind the reviewer gate (`Ruben35` / `IzuOvando`). All secrets passed via `env:` blocks.
- **`release.yml`** — Triggered on `v*` tags. SSHes into KVM and retags `:main` → `:<tag>` + `:latest`. No migrations step (frontend only).

## Evidence 📷

All three workflows implement the same patterns as the monolith pipeline:
- All external action SHAs pinned (`actions/checkout`, `actions/setup-node`, `appleboy/ssh-action`)
- `cancel-in-progress: false` on every deploy concurrency group
- Reviewer gate on the `deploy-production` **job** (not a pre-check job)
- `staging → production` order enforced by `needs:`
- `command_timeout` on all SSH steps (30m build, 10m retag)
- `trap 'rm -rf /tmp/dashboard-build' EXIT` ensures cleanup even on build failure

## Checklist 📋

- [x] ⏭️ PR Branch has been **rebased** with `main`.
- [x] 🔎 Code and Functionality has been **self-reviewed** by the author.
- [x] 📝 PR Template has been **filled out**.

## Test plan 🧪

- [ ] Merge this PR and verify **ci.yml** triggers on the next open PR — check that lint and type-check steps pass.
- [ ] Verify **build.yml** triggers on merge to `main` — confirm the KVM SSH step clones, builds, and pushes `registry.pegazzoauto.com/pegazzo-dashboard:main`.
- [ ] Confirm `staging` deploy fires automatically after build completes, and Dokploy brings the new container up on the staging environment.
- [ ] Confirm `production` deploy waits for reviewer approval (`Ruben35` or `IzuOvando`), then fires after approval.
- [ ] Push a `v*` tag and verify **release.yml** SSHes into KVM and produces `:<tag>` and `:latest` tags alongside `:main`.
- [ ] Simulate a build failure (introduce a syntax error in a branch) and confirm the pipeline fails loudly and `/tmp/dashboard-build` is cleaned up on the KVM.
- [ ] Verify the GitHub Environments `staging` and `production` are configured in repo Settings → Environments with the correct protection rules before merging.